### PR TITLE
tiagonbotelho/ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test

--- a/.github/workflows/publish_latest_version_to_gh.yml
+++ b/.github/workflows/publish_latest_version_to_gh.yml
@@ -1,0 +1,33 @@
+name: Check version and publish package
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  compare_versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Compare current repo version with all published versions
+        id: compare_versions
+        continue-on-error: false
+        run: |
+          package_name="$(npm run env | grep npm_package_name | cut -d '=' -f 2)"
+          repo_version="$(npm run env | grep npm_package_version | cut -d '=' -f 2)"
+          echo "Repo version is: $repo_version "
+
+          npm config set //npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
+          npm config set @npm:registry=https://npm.pkg.github.com/ 
+
+          versions_list="$(npm view $package_name versions | tr -d '[,]')"
+          echo "Published package versions: $versions_list "
+
+          [[ "${versions_list}" =~ "'${repo_version}'" ]] && echo "::set-output name=should_publish::false" ||  echo "::set-output name=should_publish::true"
+
+        shell: bash
+
+      - name: Publish package
+        if: steps.compare_versions.outputs.should_publish == 'true'
+        run: npm publish


### PR DESCRIPTION
We didn't seem to have any notion of CI/CD on this package.

This PR introduces both a very rudimental way of testing our package against a series of node versions that we support on other services as well as adds a way for us to automatically release a new version of this package once we merge a PR to master.
